### PR TITLE
Fix linker complaints about libdl and pthread

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,7 +54,7 @@ target_include_directories(ImGradientHDR PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/inc
 target_include_directories(test PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/include ${CMAKE_CURRENT_SOURCE_DIR}/src ${OPENGL_INCLUDE_DIR})
 target_link_directories(test PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/lib)
 
-target_link_libraries(test PRIVATE glfw3 imgui ImGradientHDR ${OPENGL_LIBRARIES})
+target_link_libraries(test PRIVATE glfw3 imgui ImGradientHDR ${OPENGL_LIBRARIES} ${CMAKE_DL_LIBS} pthread)
 
 
 if(MSVC)


### PR DESCRIPTION
Fix linker complaints about libdl and pthread

First of all, thank you for creating this module!
While building the code, it threw this error:
```
$ make ..
[...]
[100%] Linking CXX executable test
/usr/bin/ld: /home/max/Documents/software_libraries/ImGradientHDR/build/lib/libglfw3.a(posix_module.c.o): undefined reference to symbol 'dlclose@@GLIBC_2.2.5'
/usr/bin/ld: /lib/x86_64-linux-gnu/libdl.so.2: error adding symbols: DSO missing from command line
collect2: error: ld returned 1 exit status
make[2]: *** [CMakeFiles/test.dir/build.make:101: test] Error 1
make[1]: *** [CMakeFiles/Makefile2:169: CMakeFiles/test.dir/all] Error 2
make: *** [Makefile:91: all] Error 2
```

The linker was complaining that it could not find `dlclose`. This was solved by specifying `libdl` with `CMAKE_DL_LIBS` in target_link_libraries.


Then it threw this:
```
$ make ..
[…]
[100%] Linking CXX executable test
/usr/bin/ld: /home/max/Documents/software_libraries/ImGradientHDR/build/lib/libglfw3.a(posix_thread.c.o): in function `_glfwPlatformCreateTls':
posix_thread.c:(.text+0x4a): undefined reference to `pthread_key_create'
/usr/bin/ld: /home/max/Documents/software_libraries/ImGradientHDR/build/lib/libglfw3.a(posix_thread.c.o): in function `_glfwPlatformDestroyTls':
posix_thread.c:(.text+0xa4): undefined reference to `pthread_key_delete'
/usr/bin/ld: /home/max/Documents/software_libraries/ImGradientHDR/build/lib/libglfw3.a(posix_thread.c.o): in function `_glfwPlatformGetTls':
posix_thread.c:(.text+0x105): undefined reference to `pthread_getspecific'
/usr/bin/ld: /home/max/Documents/software_libraries/ImGradientHDR/build/lib/libglfw3.a(posix_thread.c.o): in function `_glfwPlatformSetTls':
posix_thread.c:(.text+0x15a): undefined reference to `pthread_setspecific'
collect2: error: ld returned 1 exit status
make[2]: *** [CMakeFiles/test.dir/build.make:101: test] Error 1
make[1]: *** [CMakeFiles/Makefile2:169: CMakeFiles/test.dir/all] Error 2
make: *** [Makefile:91: all] Error 2
```
The linker was complaining that it could not find `pthread`. This was solved by specifying `pthread`  in target_link_libraries.

After this, I was able to run the test. 
![Screenshot from 2022-01-31 19-25-31](https://user-images.githubusercontent.com/15704013/151852576-ee173c29-d3dd-4afe-8f93-8d235e35739f.png)

